### PR TITLE
Allow temporary credentials

### DIFF
--- a/src/ConfigOptions.ts
+++ b/src/ConfigOptions.ts
@@ -3,6 +3,7 @@ import * as KVSWebRTC from "amazon-kinesis-video-streams-webrtc";
 type AWSCredentials = {
   accessKeyId: string;
   secretAccessKey: string;
+  sessionToken?: string;
 };
 
 type MediaConfig = {

--- a/src/hooks/useIceServers.ts
+++ b/src/hooks/useIceServers.ts
@@ -22,7 +22,7 @@ export function useIceServers(
   const {
     channelARN,
     channelEndpoint,
-    credentials: { accessKeyId = "", secretAccessKey = "" } = {},
+    credentials: { accessKeyId = "", secretAccessKey = "", sessionToken = undefined} = {},
     region,
   } = config;
   const [error, setError] = useState<Error>();
@@ -41,6 +41,7 @@ export function useIceServers(
         credentials: {
           accessKeyId,
           secretAccessKey,
+          sessionToken,
         },
         endpoint: channelEndpoint,
       }

--- a/src/hooks/useSignalingClient.ts
+++ b/src/hooks/useSignalingClient.ts
@@ -32,34 +32,17 @@ export function useSignalingClient(config: SignalingClientConfigOptions): {
       return;
     }
 
-    if (signalingClient) {
-      signalingClient.on("close", () => {
-        setSignalingClient(
-          new SignalingClient({
-            channelARN,
-            channelEndpoint,
-            clientId,
-            credentials: { accessKeyId, secretAccessKey, sessionToken },
-            region,
-            role,
-            systemClockOffset,
-          })
-        );
-      });
-      setSignalingClient(undefined);
-    } else {
-      setSignalingClient(
-        new SignalingClient({
-          channelARN,
-          channelEndpoint,
-          clientId,
-          credentials: { accessKeyId, secretAccessKey, sessionToken },
-          region,
-          role,
-          systemClockOffset,
-        })
-      );
-    }
+    setSignalingClient(
+      new SignalingClient({
+        channelARN,
+        channelEndpoint,
+        clientId,
+        credentials: { accessKeyId, secretAccessKey, sessionToken },
+        region,
+        role,
+        systemClockOffset,
+      })
+    );
   }, [
     accessKeyId,
     channelARN,

--- a/src/hooks/useSignalingClient.ts
+++ b/src/hooks/useSignalingClient.ts
@@ -12,7 +12,7 @@ export function useSignalingClient(config: SignalingClientConfigOptions): {
   const {
     channelARN,
     channelEndpoint,
-    credentials: { accessKeyId = "", secretAccessKey = "" } = {},
+    credentials: { accessKeyId = "", secretAccessKey = "", sessionToken = undefined } = {},
     clientId,
     region,
     role,
@@ -37,7 +37,7 @@ export function useSignalingClient(config: SignalingClientConfigOptions): {
         channelARN,
         channelEndpoint,
         clientId,
-        credentials: { accessKeyId, secretAccessKey },
+        credentials: { accessKeyId, secretAccessKey, sessionToken },
         region,
         role,
         systemClockOffset,
@@ -51,6 +51,7 @@ export function useSignalingClient(config: SignalingClientConfigOptions): {
     region,
     role,
     secretAccessKey,
+    sessionToken,
     systemClockOffset,
   ]);
 

--- a/src/hooks/useSignalingClient.ts
+++ b/src/hooks/useSignalingClient.ts
@@ -32,17 +32,34 @@ export function useSignalingClient(config: SignalingClientConfigOptions): {
       return;
     }
 
-    setSignalingClient(
-      new SignalingClient({
-        channelARN,
-        channelEndpoint,
-        clientId,
-        credentials: { accessKeyId, secretAccessKey, sessionToken },
-        region,
-        role,
-        systemClockOffset,
-      })
-    );
+    if (signalingClient) {
+      signalingClient.on("close", () => {
+        setSignalingClient(
+          new SignalingClient({
+            channelARN,
+            channelEndpoint,
+            clientId,
+            credentials: { accessKeyId, secretAccessKey, sessionToken },
+            region,
+            role,
+            systemClockOffset,
+          })
+        );
+      });
+      setSignalingClient(undefined);
+    } else {
+      setSignalingClient(
+        new SignalingClient({
+          channelARN,
+          channelEndpoint,
+          clientId,
+          credentials: { accessKeyId, secretAccessKey, sessionToken },
+          region,
+          role,
+          systemClockOffset,
+        })
+      );
+    }
   }, [
     accessKeyId,
     channelARN,

--- a/src/hooks/useViewer.ts
+++ b/src/hooks/useViewer.ts
@@ -214,6 +214,7 @@ export function useViewer(
       );
       peerConnection.removeEventListener("track", handlePeerTrack);
       peerConnection.close();
+      setPeerConnection(undefined);
     };
   }, [
     clientId,

--- a/src/hooks/useViewer.ts
+++ b/src/hooks/useViewer.ts
@@ -214,7 +214,6 @@ export function useViewer(
       );
       peerConnection.removeEventListener("track", handlePeerTrack);
       peerConnection.close();
-      setPeerConnection(undefined);
     };
   }, [
     clientId,


### PR DESCRIPTION
Allow using temporary credentials, for example when using amplify + cognito authentication.

Couldn't test because  currently I'm getting a failure in the viewer example,
```
Property 'media' does not exist on type 'Peer | undefined'.
```

here
```
  const {
    error,
    peer: { media },
  } = useViewer(config);
```
If you could help me with that issue I can polish this PR :)
